### PR TITLE
Github Action ubuntu build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,39 @@
+name: build
+on:
+  push:
+    paths-ignore:
+      - .gitignore
+      - "*.md"
+  pull_request:
+    paths-ignore:
+      - .gitignore
+      - "*.md"
+
+env:
+  native_deps: build-essential debootstrap jq git xorriso grub-common grub-efi-amd64-bin grub-pc-bin mtools squashfs-tools unzip ccache
+  
+jobs:
+  build:
+    strategy:
+      matrix:
+        include:
+          - os: ubuntu-18.04
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v2
+      - name: Install dependencies (ubuntu)
+        if: matrix.os == 'ubuntu-18.04'
+        run: |
+          sudo apt-get update &&
+          sudo apt-get install -y ${{ env.native_deps }}
+      - name: Checkout
+        run: make checkout
+      - name: Packages
+        run: make packages
+      - name: Update
+        run: make update
+      - name: Iso
+        run: make iso
+      - name: Clean
+        run: make clean
+      

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,13 +27,12 @@ jobs:
           sudo apt-get update &&
           sudo apt-get install -y ${{ env.native_deps }}
       - name: Checkout
-        run: make checkout
+        run: sudo make checkout
       - name: Packages
-        run: make packages
+        run: sudo make packages
       - name: Update
-        run: make update
+        run: sudo make update
       - name: Iso
-        run: make iso
+        run: sudo make iso
       - name: Clean
-        run: make clean
-      
+        run: sudo make clean


### PR DESCRIPTION
This will add a build test in ubuntu 18.04 to validate that no changes have broken the build. This should allow for easy expanding to more OS by just adding more lines to the include section on line 19, and adding their method for installing dependencies if apt is not applicable. This is set to run on both push and pull requests.

Closes #16 