### PR TITLE
NAS-107334 \ Build ZFS with QAT support

### DIFF
--- a/scripts/mk-zfs-modules
+++ b/scripts/mk-zfs-modules
@@ -5,10 +5,31 @@ db_set zfs-dkms/note-incompatible-licenses "true"
 
 #KERNEL_VERSION=4.19.0-5-amd64 # could be a Jenkins parameter
 KERNEL_VERSION=$(dpkg --get-selections | grep -e "^linux-image-[0-9]" | awk '{print $1}' | sed 's|linux-image-||g')
+export KERNEL_SOURCE_ROOT=/lib/modules/${KERNEL_VERSION}/build
 
 apt -qyy install \
 	linux-image-${KERNEL_VERSION} \
-	linux-headers-${KERNEL_VERSION}
+	linux-headers-${KERNEL_VERSION} \
+	pciutils \
+	wget \
+	pkg-config \
+	git \
+	libudev-dev
+	
+# Setup QAT driver
+mkdir -p /QAT/FETCH
+wget https://01.org/sites/default/files/downloads/qat1.7.l.4.10.0-00014.tar.gz -O /QAT/FETCH/qat.tar.gz
+wget https://raw.githubusercontent.com/spdk/spdk/master/test/common/config/pkgdep/patches/qat/0001-timespec.patch -O /QAT/FETCH/0001-timespec.patch
+cd /QAT
+tar zxvf /QAT/FETCH/qat.tar.gz -C /QAT
+git apply FETCH/0001-timespec.patch
+rm -Rf /QAT/FETCH
+chown -R root:root  /QAT
+export ICP_ROOT=/QAT
+./configure --enable-kapi
+make
+cd -
+
 apt -qyy install zfs-dkms
 
 DRIVER_VERSION=$(dkms status zfs | awk -F', ' '{print $2}')

--- a/scripts/mk-zfs-modules
+++ b/scripts/mk-zfs-modules
@@ -7,6 +7,7 @@ db_set zfs-dkms/note-incompatible-licenses "true"
 KERNEL_VERSION=$(dpkg --get-selections | grep -e "^linux-image-[0-9]" | awk '{print $1}' | sed 's|linux-image-||g')
 export KERNEL_SOURCE_ROOT=/lib/modules/${KERNEL_VERSION}/build
 
+
 apt -qyy install \
 	linux-image-${KERNEL_VERSION} \
 	linux-headers-${KERNEL_VERSION} \
@@ -18,17 +19,14 @@ apt -qyy install \
 	
 # Setup QAT driver
 mkdir -p /QAT/FETCH
-wget https://01.org/sites/default/files/downloads/qat1.7.l.4.10.0-00014.tar.gz -O /QAT/FETCH/qat.tar.gz
-wget https://raw.githubusercontent.com/spdk/spdk/master/test/common/config/pkgdep/patches/qat/0001-timespec.patch -O /QAT/FETCH/0001-timespec.patch
-cd /QAT
+wget https://01.org/sites/default/files/downloads/qat1.7.l.4.11.0-00001.tar.gz -O /QAT/FETCH/qat.tar.gz
 tar zxvf /QAT/FETCH/qat.tar.gz -C /QAT
-git apply FETCH/0001-timespec.patch
-rm -Rf /QAT/FETCH
 chown -R root:root  /QAT
-export ICP_ROOT=/QAT
+cd /QAT
 ./configure --enable-kapi
 make
 cd -
+export ICP_ROOT=/QAT
 
 apt -qyy install zfs-dkms
 


### PR DESCRIPTION
Currently SCALE only builds the ZFS kernel module without QAT support.
This PR builds ZFS with QAT support baked-in.

It does not add the QAT drivers to the SCALE build, just makes sure ZFS is compatible with QAT. This way experienced users could install the drivers themselves and get QAT running without needing to rebuild ZFS

TODO:
- Include QAT driver/software with TrueNAS (in later PR or never)

Notes:
- While I don't expect QAT to be officially supported by IX, at least including it in the build makes it easier for people to enable it manually (without rebuilding ZFS)
- I don't think there is a nice way of adding the actual QAT driver to SCALE... No idea honestly. So this is just a patch for having ZFS support QAT so people don't have to rebuild ZFS to get WAT support

Signed-off-by: Kjeld Schouten-Lebbing <kjeld@schouten-lebbing.nl>