### PR TITLE
Add firmware-bnx2 package to TrueNAS build

### DIFF
--- a/conf/build.manifest
+++ b/conf/build.manifest
@@ -46,6 +46,7 @@
 	"base-packages": [
 		"dosfstools",
 		"consul",
+		"firmware-bnx2",
 		"grub-pc",
 		"grub-pc-bin",
 		"grub-efi-amd64",


### PR DESCRIPTION
This is required for ethernet to function on many Dell servers, including my R710