### PR TITLE
Upload the ISO Files from CI Runs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -36,3 +36,7 @@ jobs:
         run: sudo make iso
       - name: Clean
         run: sudo make clean
+      - uses: actions/upload-artifact@v2
+        with:
+          name: TrueNAS ISO
+          path: ./tmp/release/*.iso


### PR DESCRIPTION
This is nice to have for testing out ISOs built from pull requests, etc. The build system did all that work creating the ISO file, why build it again locally to test it?