### PR TITLE
Change Step Order to Fix ISO Upload

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,9 +34,9 @@ jobs:
         run: sudo make update
       - name: Iso
         run: sudo make iso
-      - name: Clean
-        run: sudo make clean
       - uses: actions/upload-artifact@v2
         with:
           name: TrueNAS ISO
           path: ./tmp/release/*.iso
+      - name: Clean
+        run: sudo make clean


### PR DESCRIPTION
In my commit yesterday I didn't notice that the clean step deletes the ISO right before it can be uploaded. This minor PR moves the clean step to after the ISO is uploaded.