### PR TITLE
[WIP] NAS-107334 \ Build ZFS with QAT support

### DIFF
--- a/conf/build.manifest
+++ b/conf/build.manifest
@@ -69,6 +69,7 @@
 		"nvidia-kernel-450.66",
 		"nvidia-container-toolkit",
 		"nvidia-smi",
+		"intel-qat",
 		"openzfs",
 		"libnvidia-encode1",
 		"squashfs-tools",
@@ -99,6 +100,11 @@
 		{
 			"name": "debootstrap",
 			"repo": "https://github.com/truenas/debootstrap",
+			"branch": "master"
+		},
+		{
+			"name": "intel_qat",
+			"repo": "https://github.com/Ornias1993/intel-qat",
 			"branch": "master"
 		},
 		{


### PR DESCRIPTION
DRAFT: This is more of a WIP playground to look into getting this running and is not supposed to work or be merged.

DRAFT DONE:
- Get QAT building on/for Kernel 5.8

DRAFT TODO:
- Get a manifest to compile source from repo on TrueNAS SCALE build
- Get the source into the ZFS buildscript
- Use the source to build ZFS with QAT support

Currently SCALE only builds the ZFS kernel module without QAT support.
This PR builds ZFS with QAT support baked-in.

It does not add the QAT drivers to the SCALE build, just makes sure ZFS is compatible with QAT. This way experienced users could install the drivers themselves and get QAT running without needing to rebuild ZFS

TODO:
- Include QAT driver/software with TrueNAS (in later PR or never)

Notes:
- While I don't expect QAT to be officially supported by IX, at least including it in the build makes it easier for people to enable it manually (without rebuilding ZFS)
- I don't think there is a nice way of adding the actual QAT driver to SCALE... No idea honestly. So this is just a patch for having ZFS support QAT so people don't have to rebuild ZFS to get WAT support

Signed-off-by: Kjeld Schouten-Lebbing <kjeld@schouten-lebbing.nl>