### PR TITLE
Add nfs4xdr-acl-tools to build

### DIFF
--- a/conf/build.manifest
+++ b/conf/build.manifest
@@ -75,6 +75,7 @@
 		"libnvidia-encode1",
 		"linux-cpupower",
 		"truenas-samba",
+		"nfs4xdr-acl-tools",
 		"netatalk",
 		"qemu-guest-agent",
 		"squashfs-tools",
@@ -106,6 +107,11 @@
 		{
 			"name": "debootstrap",
 			"repo": "https://github.com/truenas/debootstrap",
+			"branch": "master"
+		},
+		{
+			"name": "nfs4xdr_acl_tools",
+			"repo": "https://github.com/truenas/nfs4xdr-acl-tools",
 			"branch": "master"
 		},
 		{


### PR DESCRIPTION
Add utilities to manipulate Samba-style XDR-formatted NFSv41 ACLs. Package is modified version nfs4-acl-tools to support the xattr format and newer NFSv4 spec. NFSv41 style auto-inheritance is not yet implemented.