### PR TITLE
Update aiohttp version

### DIFF
--- a/conf/build.manifest
+++ b/conf/build.manifest
@@ -312,6 +312,11 @@
 			"branch": "main"
 		},
 		{
+			"name": "python_aiohttp",
+			"repo": "https://salsa.debian.org/python-team/packages/python-aiohttp.git",
+			"branch": "debian/3.7.3-1"
+		},
+		{
 			"name": "truenas_files",
 			"repo": "https://github.com/freenas/freenas",
 			"branch": "master",


### PR DESCRIPTION
We are seeing an issue after recent update of debian packages where aiohttp does not parse the URI correctly - however this is not reproducible on aiohttp 3.7.3 version which is the latest available and debian upstream just tagged it but it isn't available yet.