### PR TITLE
Add support for build epoch counter. This allows us to bump the number

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 /logs/
 /sources/
 /tmp/
+/.buildEpoch

--- a/conf/build.manifest
+++ b/conf/build.manifest
@@ -94,6 +94,7 @@
 		"libgdk-pixbuf2.0-0",
 		"x11-common"
 	],
+	"build-epoch":1,
 	"additional-packages": [
 		{
 			"package": "xtail",

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -821,14 +821,28 @@ build_update_image() {
 	echo "`date`: Success! Update image created at: ${RELEASE_DIR}/TrueNAS-SCALE.update"
 }
 
+check_epoch() {
+
+	local epoch=$(jq -r '."build-epoch"' $MANIFEST)
+	if [ -e ".buildEpoch" ] ; then
+		if [ "$(cat .buildEpoch)" != "$epoch" ] ; then
+			echo "Build epoch changed! Removing temporary files and forcing clean build."
+			cleanup
+			echo "$epoch" > .buildEpoch
+		fi
+	else
+		echo "$epoch" > .buildEpoch
+	fi
+}
+
 # Check that host has all the prereq tools installed
 preflight_check
 
 case $1 in
-	checkout) checkout_sources ;;
+	checkout) check_epoch ; checkout_sources ;;
 	clean) cleanup ;;
 	iso) build_iso ;;
-	packages) build_deb_packages ;;
+	packages) check_epoch ; build_deb_packages ;;
 	update) build_update_image ;;
 	*) exit_err "Invalid build option!" ;;
 esac


### PR DESCRIPTION
anytime we want to force downstream builders to perform a full rebuild
and invalidate any local incremental cache.